### PR TITLE
Replace project-imas.com with project-imas.wiki

### DIFF
--- a/webui/partials/chara_box.html
+++ b/webui/partials/chara_box.html
@@ -13,8 +13,7 @@
 <div class="va unbordered box black" style="width:100%">
   <div class="content">
     <div class="table_stub" style="padding-top:10px">
-      <a class="image_switch" href="http://cgdex.project-imas.com/?v=idols&o=Name%20LIKE%20%22{{ chara.conventional }}%22">CGdex</a>
-      <a class="image_switch" href="http://www.project-imas.com/wiki/{{ starlight.en.westernized_name(chara).replace(" ", "_") }}">Project iM@S Wiki</a>
+      <a class="image_switch" href="http://www.project-imas.wiki/{{ starlight.en.westernized_name(chara).replace(" ", "_") }}">Project iM@S Wiki</a>
       <a class="image_switch" href="/sprite_go_ex/{{ chara.chara_id }}">Many faces</a>
       <a class="image_switch" onclick="load_table('va_chara_{{ chara.chara_id }}', 1, [{{ chara.chara_id }}], this)">Show character lines</a>
     </div>


### PR DESCRIPTION
This PR will:
1. Replace `project-imas.com` with `project-imas.wiki`, as `project-imas.com` no longer exists.
2. Remove the CGDex link because the subdomain no longer exists and doesn't exist on `project-imas.wiki`.